### PR TITLE
Display QRcode for easy wallet export

### DIFF
--- a/lnbits/core/templates/core/wallet.html
+++ b/lnbits/core/templates/core/wallet.html
@@ -224,6 +224,14 @@
         >
         <h6 class="text-subtitle1 q-mt-none q-mb-sm">LNbits wallet</h6>
         <strong>Wallet name: </strong><em>{{ wallet.name }}</em><br />
+        <p></p>
+        <strong>Scan this QRcode to open this wallet somewhere else (e.g. your cell phone)</strong><p></p>
+        <q-responsive :ratio="1" class="q-mx-xl">
+          <qrcode
+            :value="'{{request.url_root}}'+'wallet?usr={{user.id}}&wal={{wallet.it}}'"
+            :options="{width:240}"
+          ></qrcode>
+        </q-responsive><p></p>
         <strong>Wallet ID: </strong><em>{{ wallet.id }}</em><br />
         <strong>Admin key: </strong><em>{{ wallet.adminkey }}</em><br />
         <strong>Invoice/read key: </strong><em>{{ wallet.inkey }}</em>


### PR DESCRIPTION
This adds a QRcode of the "url_root/wallet?usr=#####&wal=####" so that
the user can create a wallet on desktop and easily use it on his phone.
Also, in a use case where the <User Manager> extension is used, the
manager can create a wallet and show the QRcode for the user to take it
(e.g. in a hotel front desk the clerk creates it and the user takes it
in his phone browser, to pay for laundry, massage, soda machine...)